### PR TITLE
Dev: Catkinize package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+##############################################################################
+# CMake
+##############################################################################
+
+cmake_minimum_required(VERSION 2.8.3)
+project(usb_serial_for_android_catkin)
+
+##############################################################################
+# Catkin
+##############################################################################
+
+find_package(catkin REQUIRED rosjava_build_tools)
+# Set the gradle targets you want catkin's make to run by default
+# e.g. usually catkin_android_setup(assembleRelease uploadArchives)
+catkin_android_setup(assembleRelease uploadArchives)
+catkin_package()
+
+
+##############################################################################
+# Installation
+##############################################################################
+
+# Deploy android libraries (.aar's) and applications (.apk's)
+install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_MAVEN_DESTINATION}/com/github/rosjava/${PROJECT_NAME}/ 
+       DESTINATION ${CATKIN_GLOBAL_MAVEN_DESTINATION}/com/github/rosjava/${PROJECT_NAME}/)

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 Juan Ignacio Ubeira
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
 task wrapper(type: Wrapper) {
     gradleVersion = '2.14.1'
 }
@@ -24,30 +8,8 @@ buildscript {
 
 apply plugin: 'catkin'
 
-
-allprojects {
-    /* A github url provides a good standard unique name for your project */
-    group 'com.github.rosjava.usb_serial_for_android_catkin_sampke'
-    version = project.catkin.pkg.version
-}
-
+// See Module's build.gradle for group name and version.
 subprojects {
-    /*
-     * The android plugin configures a few things:
-     *
-     *  - local deployment repository : where it dumps the jars and packaged artifacts)
-     *  - local maven repositories    : where it finds your locally installed/built artifacts)
-     *  - external maven repositories : where it goes looking if it can't find dependencies locally
-     *  - android build tools version : which version we use across the board
-     *
-     * To modify, or add repos to the default external maven repositories list, pull request against this code:
-     *
-     *   https://github.com/rosjava/rosjava_bootstrap/blob/kinetic/gradle_plugins/src/main/groovy/org/ros/gradle_plugins/RosPlugin.groovy#L31
-     *
-     * To modify the build tools version, pull request against this code:
-     *
-     *   https://github.com/rosjava/rosjava_bootstrap/blob/kinetic/gradle_plugins/src/main/groovy/org/ros/gradle_plugins/RosAndroid.groovy#L14
-     */
     apply plugin: 'ros-android'
 
     afterEvaluate { project ->

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,63 @@
-// Top-level gradle script.
+/*
+ * Copyright (C) 2017 Juan Ignacio Ubeira
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
-    }
+task wrapper(type: Wrapper) {
+    gradleVersion = '2.14.1'
 }
 
+buildscript {
+    apply from: "https://github.com/rosjava/android_core/raw/kinetic/buildscript.gradle"
+}
+
+apply plugin: 'catkin'
+
+
 allprojects {
-    repositories {
-        mavenCentral()
+    /* A github url provides a good standard unique name for your project */
+    group 'com.github.rosjava.usb_serial_for_android_catkin_sampke'
+    version = project.catkin.pkg.version
+}
+
+subprojects {
+    /*
+     * The android plugin configures a few things:
+     *
+     *  - local deployment repository : where it dumps the jars and packaged artifacts)
+     *  - local maven repositories    : where it finds your locally installed/built artifacts)
+     *  - external maven repositories : where it goes looking if it can't find dependencies locally
+     *  - android build tools version : which version we use across the board
+     *
+     * To modify, or add repos to the default external maven repositories list, pull request against this code:
+     *
+     *   https://github.com/rosjava/rosjava_bootstrap/blob/kinetic/gradle_plugins/src/main/groovy/org/ros/gradle_plugins/RosPlugin.groovy#L31
+     *
+     * To modify the build tools version, pull request against this code:
+     *
+     *   https://github.com/rosjava/rosjava_bootstrap/blob/kinetic/gradle_plugins/src/main/groovy/org/ros/gradle_plugins/RosAndroid.groovy#L14
+     */
+    apply plugin: 'ros-android'
+
+    afterEvaluate { project ->
+        android {
+            // Exclude a few files that are duplicated across our dependencies and
+            // prevent packaging Android applications.
+            packagingOptions {
+                exclude "META-INF/LICENSE.txt"
+                exclude "META-INF/NOTICE.txt"
+            }
+        }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package>
   <name>usb_serial_for_android_catkin</name>
   <version>0.2.0</version>
-  <description>The usb_serial_for_android_catkin package</description>
+  <description>A catkin wrapper for usb_serial_for_android package</description>
 
   <maintainer email="opensource@hoho.com">Mike Wakerly</maintainer>
   <author email="opensource@hoho.com">Mike Wakerly</author>

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package>
+  <name>usb_serial_for_android_catkin</name>
+  <version>0.2.0</version>
+  <description>The usb_serial_for_android_catkin package</description>
+
+  <maintainer email="opensource@hoho.com">Mike Wakerly</maintainer>
+  <author email="opensource@hoho.com">Mike Wakerly</author>
+
+  <license>LGPLv2.1</license>
+
+  <url type="website">https://github.com/mik3y/usb-serial-for-android</url>
+  <url type="repository">https://github.com/ekumenlabs/usb-serial-for-android</url>
+  <url type="licence">http://www.gnu.org/licenses/lgpl-2.1.txt</url>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>rosjava_build_tools</build_depend>
+
+  <export>
+  </export>
+</package>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include 'usbSerialForAndroid', 'usbSerialExamples'
+include 'usbSerialForAndroid'

--- a/usbSerialForAndroid/build.gradle
+++ b/usbSerialForAndroid/build.gradle
@@ -29,7 +29,7 @@ configurations {
 }
 
 signing {
-    required { has("release") && gradle.taskGraph.hasTask("uploadArchives") }
+    required { hasProperty("release") && gradle.taskGraph.hasTask("uploadArchives") }
     sign configurations.archives
 }
 
@@ -46,25 +46,9 @@ def isReleaseBuild() {
 }
 
 uploadArchives {
-    def sonatypeRepositoryUrl
-    if (isReleaseBuild()) {
-        println 'RELEASE BUILD'
-        sonatypeRepositoryUrl = hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
-                : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-    } else {
-        println 'SNAPSHOT BUILD'
-        sonatypeRepositoryUrl = hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
-                : "https://oss.sonatype.org/content/repositories/snapshots/"
-    }
-
     configuration = configurations.archives
     repositories.mavenDeployer {
         beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-
-        repository(url: sonatypeRepositoryUrl) {
-            authentication(userName: getRepositoryUsername(),
-                    password: getRepositoryPassword())
-        }
 
         pom.artifactId = 'usb-serial-for-android'
         pom.project {


### PR DESCRIPTION
This PR adds the files required by Catkin to be able to compile the package and generate Maven artifacts using Catkin Make.
The Gradle scripts were upgraded to the ones that are currently used in RosJava Kinetic.

The metadata that is inserted into the resulting artifact is still the original one written by the author. 

The sources of the original package were used at [this point](https://github.com/mik3y/usb-serial-for-android/tree/b96f9ca7a25f44e997e1b5cb5746eb8082716168).